### PR TITLE
Invalidate diagram cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ Current schemas are in https://simplifier.net/FinnishPHR
 
 *Initial version from an old architecture document, to be updated*
 
-![Data model](http://g.gravizo.com/source?https%3A%2F%2Fraw.githubusercontent.com%2Fomahoito%2Frfc%2Fmaster%2Fmodel.dot%3F1)
+![Data model](http://g.gravizo.com/source?https%3A%2F%2Fraw.githubusercontent.com%2Fomahoito%2Frfc%2Fmaster%2Fmodel.dot%3F2)
 <!-- Increment the last number (after %3F) to invalidate gravizo and browser cache -->


### PR DESCRIPTION
404 error is cached. Increase query parameter to display the diagram.